### PR TITLE
fix Faraday gem warning

### DIFF
--- a/lib/linked_in/api.rb
+++ b/lib/linked_in/api.rb
@@ -11,8 +11,8 @@ module LinkedIn
       @connection =
         LinkedIn::Connection.new params: default_params, headers: default_headers do |conn|
         conn.request :multipart
-        conn.adapter Faraday.default_adapter
       end
+      @connection.adapter Faraday.default_adapter
 
       initialize_endpoints
     end


### PR DESCRIPTION
WARNING: Unexpected middleware set after the adapter. This won't be supported from Faraday 1.0.